### PR TITLE
Fixes #79

### DIFF
--- a/classes/models/class-post-taxonomy.php
+++ b/classes/models/class-post-taxonomy.php
@@ -62,8 +62,8 @@ class Post_Taxonomy extends Model {
 	/**
 	 * @return int
 	 */
-	public function get_term_order() {
-		return $this->term_order;
-	}
+	 public function get_term_order() {
+     return ( $this->term_order !== null ) ? $this->term_order : 0;
+   }
 
 }


### PR DESCRIPTION
Fixes #79 where the post / taxonomy relationship would break when `term_order` was null.

Signed-off-by: Christopher James Maio <cjmaio@uwm.edu>