### PR TITLE
Fixes #9

### DIFF
--- a/classes/class-setup.php
+++ b/classes/class-setup.php
@@ -93,14 +93,21 @@ class Setup {
 	/**
 	 * Display a "Deploy To Production" button whenever a post is updated.
 	 */
-	public function quick_deploy_batch() {
-		if ( isset( $_GET['post'] ) && isset( $_GET['action'] ) && isset( $_GET['message'] ) && $_GET['action'] == 'edit' ) {
-			?>
-			<div class="updated">
-				  <p><?php echo '<a href="' . admin_url( 'admin-post.php?action=sme-quick-deploy-batch&post_id=' . $_GET['post'] ) . '">Deploy To Production</a>'; ?></p>
-			</div>
-			<?php
+
+	public function quick_deploy_batch( $messages ) {
+		global $post;
+
+		$post_ID = $post->ID;
+		$post_type = get_post_type( $post_ID );
+
+		$obj = get_post_type_object( $post_type );
+		$singular = $obj->labels->singular_name;
+
+		foreach ( $messages[$post_type] as $key => $message ) {
+			$messages[$post_type][$key] = $message . ' or <a href="' . admin_url( 'admin-post.php?action=sme-quick-deploy-batch&post_id=' . $_GET['post'] ) . '">Deploy To Production</a>';
 		}
+
+		return $messages;
 	}
 
 	/**

--- a/content-staging.php
+++ b/content-staging.php
@@ -185,7 +185,6 @@ class Content_Staging {
 		add_action( 'init', array( $setup, 'register_post_types' ) );
 		add_action( 'init', array( $importer_factory, 'run_background_import' ) );
 		add_action( 'admin_menu', array( $setup, 'register_menu_pages' ) );
-		add_action( 'admin_notices', array( $setup, 'quick_deploy_batch' ) );
 		add_action( 'admin_enqueue_scripts', array( $setup, 'load_assets' ) );
 
 		// Routing.
@@ -199,6 +198,7 @@ class Content_Staging {
 		// Filters.
 		add_filter( 'xmlrpc_methods', array( $setup, 'register_xmlrpc_methods' ) );
 		add_filter( 'sme_post_relationship_keys', array( $setup, 'set_postmeta_post_relation_keys' ) );
+		add_filter( 'post_updated_messages', array( $setup, 'quick_deploy_batch' ) );
 
 		// Content Staging loaded.
 		do_action( 'content_staging_loaded' );


### PR DESCRIPTION
Adds the deploy message to the actual updated message from WordPress, rather than a separate alert.

Signed-off-by: Christopher James Maio cjmaio@uwm.edu
